### PR TITLE
feat: add onQuarterFrame callback and portIndex constructor param

### DIFF
--- a/mtcreceiver.cpp
+++ b/mtcreceiver.cpp
@@ -5,6 +5,7 @@
  * Authors:
  *   Alex Ramos <alex@stagelab.coop>
  *   Ion Reguera <ion@stagelab.coop>
+ *   Adrià Masip <adria@stagelab.coop>
  *
  * This file is part of cuems-videocomposer.
  *
@@ -39,6 +40,7 @@ std::atomic<long int> MtcReceiver::mtcHead(0);
 std::atomic<unsigned char> MtcReceiver::curFrameRate(25);
 bool MtcReceiver::wasLastUpdateFullFrame = false;
 MtcFrame MtcReceiver::curFrame;  // Initialize static curFrame
+std::function<void(long)> MtcReceiver::onQuarterFrame = nullptr;
 
 // Configurable timeouts - defaults are for local MIDI
 long int MtcReceiver::activeTimeoutNs = 50000000L;    // 50ms
@@ -58,9 +60,10 @@ MtcFrame MtcReceiver::getCurFrame() {
 }
 
 //////////////////////////////////////////////////////////
-MtcReceiver::MtcReceiver( 	RtMidi::Api api, 
+MtcReceiver::MtcReceiver( 	RtMidi::Api api,
 							const std::string& clientName,
-							unsigned int queueSizeLimit) :
+							unsigned int queueSizeLimit,
+							unsigned int portIndex) :
 							RtMidiIn( api, clientName, queueSizeLimit ) {
     // Check for midi ports available
     if ( RtMidiIn::getPortCount() == 0 ) {
@@ -80,12 +83,12 @@ MtcReceiver::MtcReceiver( 	RtMidi::Api api,
     RtMidiIn::ignoreTypes( false, false, false );
 	CuemsLogger::getLogger()->logInfo("going to open midi port");
 
-    // Then, at last, open midi default port
-    RtMidiIn::openPort( 0, "MTC recv port");
+    // Then, at last, open midi port (portIndex selects which port to use)
+    RtMidiIn::openPort( portIndex, "MTC recv port");
 
 	if (!RtMidiIn::isPortOpen()){
 		CuemsLogger::getLogger()->logWarning("first try to open midi port failed, trying again");
-		RtMidiIn::openPort( 0, "MTC recv port");
+		RtMidiIn::openPort( portIndex, "MTC recv port");
 	}
     
     clientStartTimestamp = ns_now();
@@ -279,6 +282,7 @@ void MtcReceiver::decodeQuarterFrame(std::vector<unsigned char> &message) {
 	// TO DO : adjust for both directions
 	// 1/4 * 1000 milliseconds * (1 / framerate)
 	mtcHead.store(mtcHead.load() + static_cast<long int>(250 / curFrame.getFps()));
+	if (onQuarterFrame) onQuarterFrame(mtcHead.load()); // Site 1: per-quarter running update
 
 	// Updating lastDataByte flag
 	lastDataByte = dataByte;
@@ -294,9 +298,10 @@ void MtcReceiver::decodeQuarterFrame(std::vector<unsigned char> &message) {
 		// Our current frame is the current quarter frame structure
 		curFrame = quarterFrame;
 
-		// We have complete valid MTC time info so, we can update 
+		// We have complete valid MTC time info so, we can update
 		// our MTC head position
 		mtcHead.store(curFrame.toMilliseconds());
+		if (onQuarterFrame) onQuarterFrame(mtcHead.load()); // Site 2: per-complete-frame decode
 		curFrameRate.store(static_cast<unsigned char>(curFrame.getFps()));
 		wasLastUpdateFullFrame = false; // Quarter-frame update (not full SYSEX)
 

--- a/mtcreceiver.h
+++ b/mtcreceiver.h
@@ -5,6 +5,7 @@
  * Authors:
  *   Alex Ramos <alex@stagelab.coop>
  *   Ion Reguera <ion@stagelab.coop>
+ *   Adrià Masip <adria@stagelab.coop>
  *
  * This file is part of cuems-videocomposer.
  *
@@ -41,6 +42,7 @@
 #define QF_LEN 8
 
 #include <atomic>
+#include <functional>
 #include <thread>
 #include <math.h>
 #include <chrono>
@@ -146,8 +148,14 @@ class MtcReceiver : public RtMidiIn
     public:
         MtcReceiver(    RtMidi::Api api = MTCRECV_DEFAULT_API,
                         const std::string& clientName = "Cuems Mtc Receiver",
-                        unsigned int queueSizeLimit = 100 );
+                        unsigned int queueSizeLimit = 100,
+                        unsigned int portIndex = 0 );
         ~MtcReceiver( void );
+
+        // Quarter-frame tick callback. Fires after every mtcHead update in
+        // decodeQuarterFrame(). Null-checked before invocation.
+        // MUST be lock-free — fires from the MIDI callback thread.
+        static std::function<void(long)> onQuarterFrame;
 
         // Stream control vars
         // These are accessed from both MIDI and audio callback threads, so must be atomic


### PR DESCRIPTION
- Add static std::function<void(long)> onQuarterFrame public member
- Initialize onQuarterFrame to nullptr in static member definitions
- Add unsigned int portIndex as last constructor parameter (default 0) to preserve positional backward compatibility for existing callers
- Use portIndex instead of hardcoded 0 in RtMidiIn::openPort() calls
- Fire onQuarterFrame after both mtcHead.store() sites in decodeQuarterFrame(): per-quarter running update (Site 1) and per-complete-frame decode (Site 2)
- decodeFullFrame() intentionally does NOT fire onQuarterFrame (SysEx seek/locate is a position jump, not a running tick)