### PR TITLE
refactor!: thread-safe single-fire-per-QF callback API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@
 
 # CMake
 build/
+build-*/
 CMakeLists.txt.user*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,10 @@
+cmake_minimum_required(VERSION 3.14)
+
+# project() is a no-op when this file is included via add_subdirectory() from
+# a parent (videocomposer, audioplayer, dmxplayer). Declaring a version lets
+# consumers probe with find_package(mtcreceiver 2.0) once this PR lands.
+project(mtcreceiver VERSION 2.0.0 LANGUAGES CXX)
+
 add_library(mtcreceiver mtcreceiver.cpp)
 
 # Include directories
@@ -9,4 +16,39 @@ target_include_directories(mtcreceiver PUBLIC
 # Link RtMidi
 if(RTMIDI_LIBRARIES)
     target_link_libraries(mtcreceiver ${RTMIDI_LIBRARIES})
+endif()
+
+# Build options (OFF by default).
+#   MTCRECV_VERBOSE_DIAG — re-enables the MIDI-thread diagnostic writes that
+#                         previously went via std::cout. Kept off in production
+#                         because cout+endl flushes block the MIDI callback.
+#   MTCRECV_TESTING     — exposes test-only helpers (invokeTickForTesting, the
+#                         SkipPortOpenTag constructor, decode forwarders, and
+#                         state reset helpers). Required by the test suite.
+#   MTCRECV_BUILD_TESTS — builds the unit test executable. Only enabled by
+#                         default when mtcreceiver is the top-level project,
+#                         never when included as a submodule.
+option(MTCRECV_VERBOSE_DIAG "Enable MTC receiver verbose diagnostic output" OFF)
+option(MTCRECV_TESTING      "Expose test-only helpers (invokeTickForTesting, etc.)" OFF)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    option(MTCRECV_BUILD_TESTS "Build mtcreceiver unit tests" ON)
+else()
+    option(MTCRECV_BUILD_TESTS "Build mtcreceiver unit tests" OFF)
+endif()
+
+if(MTCRECV_VERBOSE_DIAG)
+    target_compile_definitions(mtcreceiver PUBLIC MTCRECV_VERBOSE_DIAG)
+endif()
+# MTCRECV_BUILD_TESTS implies MTCRECV_TESTING — tests need the test-only API.
+if(MTCRECV_BUILD_TESTS)
+    set(MTCRECV_TESTING ON CACHE BOOL "Expose test-only helpers" FORCE)
+endif()
+if(MTCRECV_TESTING)
+    target_compile_definitions(mtcreceiver PUBLIC MTCRECV_TESTING)
+endif()
+
+if(MTCRECV_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
 endif()

--- a/mtcreceiver.cpp
+++ b/mtcreceiver.cpp
@@ -33,14 +33,19 @@
 
 #include "mtcreceiver.h"
 
+#include <cstdio>
+
 ////////////////////////////////////////////
 // Initializing static class members
 std::atomic<bool> MtcReceiver::isTimecodeRunning(false);
 std::atomic<long int> MtcReceiver::mtcHead(0);
 std::atomic<unsigned char> MtcReceiver::curFrameRate(25);
-bool MtcReceiver::wasLastUpdateFullFrame = false;
+std::atomic<bool> MtcReceiver::wasLastUpdateFullFrame(false);
 MtcFrame MtcReceiver::curFrame;  // Initialize static curFrame
-std::function<void(long)> MtcReceiver::onQuarterFrame = nullptr;
+
+std::mutex MtcReceiver::callbackMutex_;
+MtcReceiver::TickCallback MtcReceiver::tickCallback_;
+std::mutex MtcReceiver::curFrameMutex_;
 
 // Configurable timeouts - defaults are for local MIDI
 long int MtcReceiver::activeTimeoutNs = 50000000L;    // 50ms
@@ -54,10 +59,68 @@ static long int ns_now() {
 }
 
 //////////////////////////////////////////////////////////
-// Get current MTC frame (like xjadeo's timecode state)
+// Get current MTC frame (like xjadeo's timecode state).
+// Returns a consistent snapshot taken under curFrameMutex_.
 MtcFrame MtcReceiver::getCurFrame() {
+    std::lock_guard<std::mutex> lk(curFrameMutex_);
     return curFrame;
 }
+
+//////////////////////////////////////////////////////////
+// Register (or clear) the quarter-frame tick callback.
+// Holding callbackMutex_ during assignment serializes with the MIDI thread's
+// invocation path, so on return (with an empty callable) the previous
+// callback is guaranteed to have finished and will not fire again.
+void MtcReceiver::setTickCallback(TickCallback cb) {
+    std::lock_guard<std::mutex> lk(callbackMutex_);
+    tickCallback_ = std::move(cb);
+}
+
+#ifdef MTCRECV_TESTING
+void MtcReceiver::invokeTickForTesting(long mtcHeadMs, bool isCompleteFrame) {
+    std::lock_guard<std::mutex> lk(callbackMutex_);
+    if (tickCallback_) tickCallback_(mtcHeadMs, isCompleteFrame);
+}
+
+// Test-only ctor: initialize the RtMidi backend but do NOT open any port and
+// do NOT start the checker thread. The decoder can be driven directly via
+// decodeQuarterFrameForTesting / decodeFullFrameForTesting.
+MtcReceiver::MtcReceiver(SkipPortOpenTag,
+                         RtMidi::Api api,
+                         const std::string& clientName,
+                         unsigned int queueSizeLimit) :
+    RtMidiIn(api, clientName, queueSizeLimit) {
+    clientStartTimestamp = ns_now();
+}
+
+void MtcReceiver::resetDecoderStateForTesting() {
+    quarterFrame = MtcFrame();
+    direction = 0;
+    lastDataByte = 0x00;
+    qfCount = 0;
+    firstQFlag = false;
+    lastQFlag = false;
+    std::lock_guard<std::mutex> lk(activeStateMutex_);
+    timecodeTimestamp = 0;
+    timecodeStartTimestamp = 0;
+    timecodeRunWeight = 0.0;
+}
+
+void MtcReceiver::resetStaticStateForTesting() {
+    {
+        std::lock_guard<std::mutex> lk(callbackMutex_);
+        tickCallback_ = TickCallback{};
+    }
+    {
+        std::lock_guard<std::mutex> lk(curFrameMutex_);
+        curFrame = MtcFrame();
+    }
+    isTimecodeRunning.store(false);
+    mtcHead.store(0);
+    curFrameRate.store(25);
+    wasLastUpdateFullFrame.store(false);
+}
+#endif
 
 //////////////////////////////////////////////////////////
 MtcReceiver::MtcReceiver( 	RtMidi::Api api,
@@ -281,29 +344,34 @@ void MtcReceiver::decodeQuarterFrame(std::vector<unsigned char> &message) {
 	// stil going on...
 	// TO DO : adjust for both directions
 	// 1/4 * 1000 milliseconds * (1 / framerate)
-	mtcHead.store(mtcHead.load() + static_cast<long int>(250 / curFrame.getFps()));
-	if (onQuarterFrame) onQuarterFrame(mtcHead.load()); // Site 1: per-quarter running update
-
-	// Updating lastDataByte flag
 	lastDataByte = dataByte;
 
 	bool reset = (qfCount != expected_qf_count);
 
-	// Update time using the (hopefully) complete message
-	if(complete) {
-		// Add a 2 frames adjust to compensate the time 
+	// Extrapolated head advance, used when the frame isn't yet complete.
+	// curFrame.getFps() is safe to read here without the mutex: this thread
+	// is the only writer, and readers of curFrame already go through the
+	// locked getCurFrame() path.
+	mtcHead.store(mtcHead.load() + static_cast<long int>(250 / curFrame.getFps()));
+	long int callbackMs = mtcHead.load();
+
+	// Update time using the (hopefully) complete message.
+	if (complete) {
+		// Add a 2 frames adjust to compensate the time
 		// it takes to receive all 8 QF messages
 		quarterFrame.frames += 2;
 
-		// Our current frame is the current quarter frame structure
-		curFrame = quarterFrame;
+		{
+			std::lock_guard<std::mutex> lk(curFrameMutex_);
+			curFrame = quarterFrame;
+		}
 
 		// We have complete valid MTC time info so, we can update
-		// our MTC head position
-		mtcHead.store(curFrame.toMilliseconds());
-		if (onQuarterFrame) onQuarterFrame(mtcHead.load()); // Site 2: per-complete-frame decode
+		// our MTC head position to the authoritative value.
+		callbackMs = curFrame.toMilliseconds();
+		mtcHead.store(callbackMs);
 		curFrameRate.store(static_cast<unsigned char>(curFrame.getFps()));
-		wasLastUpdateFullFrame = false; // Quarter-frame update (not full SYSEX)
+		wasLastUpdateFullFrame.store(false); // Quarter-frame update (not full SYSEX)
 
 		// Reset quarter frame structure and detection flags
 		quarterFrame = MtcFrame();
@@ -312,61 +380,83 @@ void MtcReceiver::decodeQuarterFrame(std::vector<unsigned char> &message) {
 		lastQFlag = firstQFlag = false;
 	}
 
-	// Note down the timestamp when the last QFrame message arrived
-	timecodeTimestamp = ns_now();
+	// Single fire per QF: one invocation carrying a flag that distinguishes
+	// extrapolated ticks (QFs 1-7) from the authoritative tick (QF 8 after
+	// full decode). Suppressed entirely when the QF sequence is invalid so
+	// consumers never see phantom ticks.
+	if (!reset) {
+		std::lock_guard<std::mutex> lk(callbackMutex_);
+		if (tickCallback_) tickCallback_(callbackMs, complete);
+	}
 
-	// W_MAX controls maximum averaging length.
-	// Higher values give better accuracy but slower adaptation.
-	constexpr const double W_MAX = 100.0;
-	long int ts_start = timecodeTimestamp - mtcHead.load() * static_cast<long int>(1e6);
+	// Note down the timestamp when the last QFrame message arrived, and run
+	// the averaging logic under activeStateMutex_ so const query methods
+	// (isTimecodeActive / estimatedCurrentHead) see a consistent snapshot.
+	{
+		std::lock_guard<std::mutex> lk(activeStateMutex_);
 
-	// Reset accumulated average if time jumps or quarter frame sequence is broken
-	// Use configurable threshold for network transport compatibility
-	if (reset || (ts_start - timecodeStartTimestamp > jumpThresholdNs) || (0.0 == timecodeRunWeight)) {
-		timecodeStartTimestamp = ts_start;
-		if (complete) {
-			timecodeRunWeight = 1.0;
+		timecodeTimestamp = ns_now();
 
-			std::cout << std::fixed << std::setprecision(3);
-			std::cout << "MTC Receiver: set start time: "
-				<< (ts_start - clientStartTimestamp) * 1e-9
-				<< std::endl;
+		// W_MAX controls maximum averaging length.
+		// Higher values give better accuracy but slower adaptation.
+		constexpr const double W_MAX = 100.0;
+		long int ts_start = timecodeTimestamp - mtcHead.load() * static_cast<long int>(1e6);
+
+		// Reset accumulated average if time jumps or quarter frame sequence is broken
+		// Use configurable threshold for network transport compatibility
+		if (reset || (ts_start - timecodeStartTimestamp > jumpThresholdNs) || (0.0 == timecodeRunWeight)) {
+			timecodeStartTimestamp = ts_start;
+			if (complete) {
+				timecodeRunWeight = 1.0;
+#ifdef MTCRECV_VERBOSE_DIAG
+				fprintf(stderr, "MTC Receiver: set start time: %.3f\n",
+					(ts_start - clientStartTimestamp) * 1e-9);
+#endif
+			}
+			else {
+#ifdef MTCRECV_VERBOSE_DIAG
+				if (0 < timecodeRunWeight) {
+					fprintf(stderr, "MTC Receiver: reset start time (QFrame): %.3f\n",
+						(ts_start - clientStartTimestamp) * 1e-9);
+				}
+#endif
+				timecodeRunWeight = 0.0;
+			}
 		}
 		else {
-			if (0 < timecodeRunWeight) {
-				std::cout << std::fixed << std::setprecision(3);
-				std::cout << "MTC Receiver: reset start time (QFrame): "
-					<< (ts_start - clientStartTimestamp) * 1e-9
-					<< std::endl;
-			}
-			timecodeRunWeight = 0.0;
+			// Regular correction
+			timecodeRunWeight += (1 - timecodeRunWeight / W_MAX);
+			timecodeStartTimestamp += static_cast<long int>((ts_start - timecodeStartTimestamp) / timecodeRunWeight);
 		}
-	}
-	else {
-		// Regular correction
-		timecodeRunWeight += (1 - timecodeRunWeight / W_MAX);
-		timecodeStartTimestamp += static_cast<long int>((ts_start - timecodeStartTimestamp) / timecodeRunWeight);
 	}
 }
 
 //////////////////////////////////////////////////////////
 void MtcReceiver::decodeFullFrame(std::vector<unsigned char> &message) {
-	curFrame.hours = (int)(message[5] & 0x1F);
-	curFrame.rate = (int)((message[5] & 0x60) >> 5);
-	curFrame.minutes = (int)(message[6]);
-	curFrame.seconds = (int)(message[7]);
-	curFrame.frames = (int)(message[8]);
+	{
+		std::lock_guard<std::mutex> lk(curFrameMutex_);
+		curFrame.hours = (int)(message[5] & 0x1F);
+		curFrame.rate = (int)((message[5] & 0x60) >> 5);
+		curFrame.minutes = (int)(message[6]);
+		curFrame.seconds = (int)(message[7]);
+		curFrame.frames = (int)(message[8]);
+		mtcHead.store(curFrame.toMilliseconds());
+	}
 
 	// A full message is always valid whole MTC time info so
 	// we can update our MTC head position
-	wasLastUpdateFullFrame = true; // Full SYSEX frame marker (like xjadeo's tick=0)
-	mtcHead.store(curFrame.toMilliseconds());
+	wasLastUpdateFullFrame.store(true); // Full SYSEX frame marker (like xjadeo's tick=0)
 
 	// Reset the averaging for the new position
-	timecodeStartTimestamp = ns_now() - mtcHead.load() * static_cast<long int>(1e6);
-	timecodeRunWeight = 0.0;
-	std::cout << "MTC Receiver: Reset start time (FFrame): "
-		<< (timecodeStartTimestamp - clientStartTimestamp) * 1e-9 << std::endl;
+	{
+		std::lock_guard<std::mutex> lk(activeStateMutex_);
+		timecodeStartTimestamp = ns_now() - mtcHead.load() * static_cast<long int>(1e6);
+		timecodeRunWeight = 0.0;
+#ifdef MTCRECV_VERBOSE_DIAG
+		fprintf(stderr, "MTC Receiver: Reset start time (FFrame): %.3f\n",
+			(timecodeStartTimestamp - clientStartTimestamp) * 1e-9);
+#endif
+	}
 }
 
 //////////////////////////////////////////////////////////
@@ -389,6 +479,7 @@ bool MtcReceiver::decodeNewMidiMessage( std::vector<unsigned char> &message ) {
 //////////////////////////////////////////////////////////
 bool MtcReceiver::isTimecodeActive() const
 {
+	std::lock_guard<std::mutex> lk(activeStateMutex_);
 	if (0.0 == timecodeRunWeight) {
 		return false;
 	}
@@ -400,6 +491,7 @@ bool MtcReceiver::isTimecodeActive() const
 //////////////////////////////////////////////////////////
 long int MtcReceiver::estimatedCurrentHead() const
 {
+	std::lock_guard<std::mutex> lk(activeStateMutex_);
 	// If MTC was stopped with FFrame or reset, return the last position
 	if (0.0 == timecodeRunWeight) {
 		return mtcHead.load();
@@ -413,8 +505,12 @@ void MtcReceiver::threadedChecker( void ) {
 	while ( checkerOn ) {
 		if ( isTimecodeRunning.load() ) {
 			long int timecodeNow = ns_now();
-			
-			long int timecodeDiff = (timecodeNow - timecodeTimestamp);
+			long int ts;
+			{
+				std::lock_guard<std::mutex> lk(activeStateMutex_);
+				ts = timecodeTimestamp;
+			}
+			long int timecodeDiff = (timecodeNow - ts);
 
 			// Use configurable timeout (convert to ns for comparison)
 			if ( timecodeDiff > activeTimeoutNs )
@@ -433,13 +529,17 @@ void MtcReceiver::setNetworkMode(bool enabled) {
 		activeTimeoutNs = 150000000L;    // 150ms - accounts for network jitter
 		runningTimeoutSec = 0.20;        // 200ms - more tolerant of gaps
 		jumpThresholdNs = 50000000L;     // 50ms - network can cause larger jumps
-		std::cout << "MTC Receiver: Network mode enabled (150ms timeout, 50ms jump threshold)" << std::endl;
+#ifdef MTCRECV_VERBOSE_DIAG
+		fprintf(stderr, "MTC Receiver: Network mode enabled (150ms timeout, 50ms jump threshold)\n");
+#endif
 	} else {
 		// Default settings for local MIDI
 		activeTimeoutNs = 50000000L;     // 50ms
 		runningTimeoutSec = 0.10;        // 100ms
 		jumpThresholdNs = 20000000L;     // 20ms
-		std::cout << "MTC Receiver: Local mode (50ms timeout, 20ms jump threshold)" << std::endl;
+#ifdef MTCRECV_VERBOSE_DIAG
+		fprintf(stderr, "MTC Receiver: Local mode (50ms timeout, 20ms jump threshold)\n");
+#endif
 	}
 }
 

--- a/mtcreceiver.h
+++ b/mtcreceiver.h
@@ -43,6 +43,7 @@
 
 #include <atomic>
 #include <functional>
+#include <mutex>
 #include <thread>
 #include <math.h>
 #include <chrono>
@@ -152,21 +153,71 @@ class MtcReceiver : public RtMidiIn
                         unsigned int portIndex = 0 );
         ~MtcReceiver( void );
 
-        // Quarter-frame tick callback. Fires after every mtcHead update in
-        // decodeQuarterFrame(). Null-checked before invocation.
-        // MUST be lock-free — fires from the MIDI callback thread.
-        static std::function<void(long)> onQuarterFrame;
+        // Quarter-frame tick callback signature.
+        //   mtcHeadMs       — current MTC head in ms (extrapolated on QFs 1-7,
+        //                     authoritative on QF 8 after full decode).
+        //   isCompleteFrame — true only on QF 8 when the full frame has just
+        //                     been decoded; false on QFs 1-7 (extrapolated).
+        // Fires at most once per valid quarter frame. Does NOT fire when the
+        // QF sequence is invalid (reset). The callback MUST be lock-free and
+        // non-blocking (<100 µs) — it runs on the RtMidi MIDI callback thread.
+        // Callers MUST NOT call setTickCallback() from within the handler.
+        using TickCallback = std::function<void(long mtcHeadMs, bool isCompleteFrame)>;
+
+        // Register (or clear, with an empty/null callable) the tick callback.
+        // Thread-safe: blocks until any in-flight invocation returns, so after
+        // this call returns with an empty callable the previous callback is
+        // guaranteed to never fire again (no-call-after-unregister).
+        static void setTickCallback(TickCallback cb);
+
+#ifdef MTCRECV_TESTING
+        // Test-only helper: synthesize a tick as if decodeQuarterFrame() had
+        // just invoked the registered callback. Gated behind MTCRECV_TESTING
+        // so production consumers cannot call it. Acquires the same mutex the
+        // MIDI thread would, so it also exercises the thread-safety path.
+        static void invokeTickForTesting(long mtcHeadMs, bool isCompleteFrame);
+
+        // Tag type used to select the test-only constructor that skips both
+        // the port-count check and openPort(), so unit tests can drive the
+        // decoder without requiring real MIDI hardware.
+        struct SkipPortOpenTag {};
+        explicit MtcReceiver(SkipPortOpenTag,
+                             RtMidi::Api api = MTCRECV_DEFAULT_API,
+                             const std::string& clientName = "Cuems Mtc Receiver Test",
+                             unsigned int queueSizeLimit = 100);
+
+        // Public forwarders for the private decode entry points, gated behind
+        // MTCRECV_TESTING so production consumers can't accidentally drive the
+        // decoder from outside. Used by the unit tests to feed synthetic MIDI
+        // byte sequences.
+        void decodeQuarterFrameForTesting(std::vector<unsigned char>& msg) {
+            decodeQuarterFrame(msg);
+        }
+        void decodeFullFrameForTesting(std::vector<unsigned char>& msg) {
+            decodeFullFrame(msg);
+        }
+
+        // Reset all per-instance decoder state (direction, qfCount, flags, the
+        // running quarterFrame buffer, and the active-state averaging). Lets
+        // each test start from a known state without constructing a new
+        // receiver.
+        void resetDecoderStateForTesting();
+
+        // Clear the static callback + curFrame state that persists across
+        // MtcReceiver instances. Call this from test SetUp to isolate tests.
+        static void resetStaticStateForTesting();
+#endif
 
         // Stream control vars
         // These are accessed from both MIDI and audio callback threads, so must be atomic
         static std::atomic<bool> isTimecodeRunning;      // Is the timecode sync running?
         static std::atomic<long int> mtcHead;              // Time code head in milliseconds
         static std::atomic<unsigned char> curFrameRate;  // Current MTC frame rate
-        static bool wasLastUpdateFullFrame; // true if last update was full SYSEX frame (for seeking)
+        static std::atomic<bool> wasLastUpdateFullFrame; // true if last update was full SYSEX frame (for seeking)
                                            // TODO: Use this in cuems-audioplayer and cuems-dmxplayer for accurate seeking
-        
-        // Get current MTC frame (like xjadeo's timecode state)
-        // Returns the current timecode frame structure (h, m, s, f, rate)
+
+        // Get current MTC frame (like xjadeo's timecode state). Returns a
+        // consistent snapshot (h, m, s, f, rate) taken under curFrameMutex_.
         static MtcFrame getCurFrame();
 
         // New versions of head position tracking with filtering and extrapolation
@@ -195,11 +246,29 @@ class MtcReceiver : public RtMidiIn
         long int timecodeStartTimestamp = 0;
         long int clientStartTimestamp = 0;
         double timecodeRunWeight = 0.0;
-        
+
+        // Protects the three instance members above (timecodeTimestamp,
+        // timecodeStartTimestamp, timecodeRunWeight). Mutable so that the
+        // const query methods (isTimecodeActive, estimatedCurrentHead) can
+        // acquire it.
+        mutable std::mutex activeStateMutex_;
+
         // Configurable timeouts for network transport
         static long int activeTimeoutNs;      // Default: 50ms (50e6 ns)
         static double runningTimeoutSec;      // Default: 0.1 seconds
         static long int jumpThresholdNs;      // Default: 20ms (20e6 ns)
+
+        // Global callback registration state. tickCallback_ is mutated under
+        // callbackMutex_; the mutex is also held during invocation so an
+        // unregister call waits for any in-flight callback to return before
+        // returning itself (no-call-after-unregister guarantee).
+        static std::mutex callbackMutex_;
+        static TickCallback tickCallback_;
+
+        // Protects reads/writes of the static curFrame (written in
+        // decodeQuarterFrame and decodeFullFrame from the MIDI thread, read
+        // via getCurFrame() from any thread).
+        static std::mutex curFrameMutex_;
 
         // Usefull functions
         bool decodeNewMidiMessage( std::vector<unsigned char> &message );

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 Stagelab Coop SCCL
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileContributor: Ion Reguera <ion@stagelab.coop>
+
+include(FetchContent)
+
+# Prefer a system gtest if one is already available, otherwise fetch v1.14.0.
+find_package(GTest QUIET)
+if(NOT GTest_FOUND)
+    FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG        v1.14.0
+    )
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
+endif()
+
+# rtmidi needs to be resolvable in standalone mode; in submodule mode the
+# parent usually sets RTMIDI_* vars. Use pkg-config as a fallback.
+if(NOT RTMIDI_LIBRARIES)
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(RTMIDI rtmidi)
+    endif()
+endif()
+
+add_executable(test_callback test_callback.cpp)
+target_link_libraries(test_callback
+    PRIVATE
+    mtcreceiver
+    GTest::gtest_main
+    ${RTMIDI_LIBRARIES}
+    pthread
+)
+target_include_directories(test_callback PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${RTMIDI_INCLUDE_DIRS}
+)
+
+include(GoogleTest)
+gtest_discover_tests(test_callback)

--- a/tests/test_callback.cpp
+++ b/tests/test_callback.cpp
@@ -1,0 +1,296 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Stagelab Coop SCCL
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileContributor: Ion Reguera <ion@stagelab.coop>
+ */
+
+#include "mtcreceiver.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using Msg = std::vector<unsigned char>;
+
+// Build a single MTC quarter-frame MIDI message for a given QF type (0-7)
+// and its 4-bit data payload. decodeQuarterFrame only reads message[1], so
+// message[0] can be anything.
+Msg qf(unsigned char type, unsigned char value) {
+    return { 0xF1, static_cast<unsigned char>((type << 4) | (value & 0x0F)) };
+}
+
+// A forward-running QF sequence for timecode 00:00:00:00 at 25 fps. QF types
+// emitted in order 0-7, each carrying zero data. Results in one completed
+// frame at the final QF.
+std::vector<Msg> forwardsZeroSequence() {
+    return {
+        qf(0, 0),  // frame LSB
+        qf(1, 0),  // frame MSB
+        qf(2, 0),  // seconds LSB
+        qf(3, 0),  // seconds MSB
+        qf(4, 0),  // minutes LSB
+        qf(5, 0),  // minutes MSB
+        qf(6, 0),  // hours LSB
+        qf(7, 2),  // hours MSB + rate; rate bits (0x06 >> 1) = 1 → 25 fps
+    };
+}
+
+class CallbackFixture : public ::testing::Test {
+protected:
+    void SetUp() override {
+        MtcReceiver::resetStaticStateForTesting();
+    }
+    void TearDown() override {
+        MtcReceiver::resetStaticStateForTesting();
+    }
+};
+
+} // namespace
+
+// ─── Registration & invocation ───────────────────────────────────────────────
+
+TEST_F(CallbackFixture, InvokeTickDeliversToRegisteredCallback) {
+    std::atomic<long> got{-1};
+    std::atomic<bool> complete{false};
+
+    MtcReceiver::setTickCallback([&](long ms, bool isComplete) {
+        got.store(ms);
+        complete.store(isComplete);
+    });
+
+    MtcReceiver::invokeTickForTesting(1234, true);
+
+    EXPECT_EQ(got.load(), 1234);
+    EXPECT_TRUE(complete.load());
+}
+
+TEST_F(CallbackFixture, UnregisterSilencesCallback) {
+    std::atomic<int> hits{0};
+    MtcReceiver::setTickCallback([&](long, bool) { hits.fetch_add(1); });
+
+    MtcReceiver::invokeTickForTesting(10, false);
+    EXPECT_EQ(hits.load(), 1);
+
+    MtcReceiver::setTickCallback({});
+    MtcReceiver::invokeTickForTesting(20, false);
+    EXPECT_EQ(hits.load(), 1);
+}
+
+TEST_F(CallbackFixture, ReplaceCallbackDropsOldOne) {
+    std::atomic<int> a{0}, b{0};
+    MtcReceiver::setTickCallback([&](long, bool) { a.fetch_add(1); });
+    MtcReceiver::setTickCallback([&](long, bool) { b.fetch_add(1); });
+
+    MtcReceiver::invokeTickForTesting(0, false);
+    EXPECT_EQ(a.load(), 0);
+    EXPECT_EQ(b.load(), 1);
+}
+
+TEST_F(CallbackFixture, InvokeWithoutCallbackIsSafe) {
+    EXPECT_NO_FATAL_FAILURE(MtcReceiver::invokeTickForTesting(42, false));
+}
+
+// ─── Thread safety (register / invoke / unregister races) ────────────────────
+
+TEST_F(CallbackFixture, ConcurrentInvokeAndRegisterIsSafe) {
+    // Stress the callbackMutex_ path: one thread registers/unregisters in a
+    // loop while another invokes. Under TSan this flags any non-atomic
+    // accesses on tickCallback_. Without the mutex this would UB on
+    // std::function's control block.
+    std::atomic<bool> stop{false};
+    std::atomic<int>  invocations{0};
+
+    std::thread invoker([&] {
+        while (!stop.load()) {
+            MtcReceiver::invokeTickForTesting(1, false);
+            invocations.fetch_add(1);
+        }
+    });
+
+    auto cb = [&](long, bool) {};
+    for (int i = 0; i < 1000; ++i) {
+        MtcReceiver::setTickCallback(cb);
+        MtcReceiver::setTickCallback({});
+    }
+    stop.store(true);
+    invoker.join();
+
+    // The invariant is "doesn't crash / no data race". The exact count depends
+    // on scheduling; a positive count just proves the invoker actually ran.
+    EXPECT_GT(invocations.load(), 0);
+}
+
+TEST_F(CallbackFixture, UnregisterBlocksUntilInFlightReturns) {
+    // setTickCallback({}) holds callbackMutex_, and the MIDI-thread invocation
+    // path holds the same mutex while the callback runs. So a slow callback
+    // makes setTickCallback block until it completes — guaranteeing the
+    // handler will not run after the unregister call returns.
+    std::atomic<bool> insideCallback{false};
+    std::atomic<bool> callbackReleased{false};
+    std::atomic<bool> callbackReturned{false};
+
+    MtcReceiver::setTickCallback([&](long, bool) {
+        insideCallback.store(true);
+        while (!callbackReleased.load()) {
+            std::this_thread::sleep_for(std::chrono::microseconds(100));
+        }
+        callbackReturned.store(true);
+    });
+
+    std::thread firing([&] { MtcReceiver::invokeTickForTesting(0, false); });
+
+    // Wait until the invoker has the mutex and is stuck inside the handler.
+    while (!insideCallback.load()) {
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
+
+    std::atomic<bool> unregisterReturned{false};
+    std::thread unregistering([&] {
+        MtcReceiver::setTickCallback({});
+        unregisterReturned.store(true);
+    });
+
+    // The unregistering thread must be blocked: the invoker still holds the
+    // mutex. Give it a moment to prove it's actually waiting.
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    EXPECT_FALSE(unregisterReturned.load())
+        << "setTickCallback({}) returned while a callback was still in flight";
+
+    callbackReleased.store(true);
+    firing.join();
+    unregistering.join();
+
+    EXPECT_TRUE(callbackReturned.load());
+    EXPECT_TRUE(unregisterReturned.load());
+
+    // Any further invocation must not reach the (now cleared) callback.
+    std::atomic<bool> shouldNotFire{false};
+    MtcReceiver::invokeTickForTesting(0, false);
+    EXPECT_FALSE(shouldNotFire.load());
+}
+
+// ─── Decoder: single-fire-per-QF with correct flag ───────────────────────────
+
+TEST_F(CallbackFixture, ForwardsSequenceFiresEightTimesOneComplete) {
+    MtcReceiver receiver(MtcReceiver::SkipPortOpenTag{});
+    receiver.resetDecoderStateForTesting();
+
+    std::vector<bool> flags;
+    MtcReceiver::setTickCallback(
+        [&](long, bool isComplete) { flags.push_back(isComplete); });
+
+    for (auto& m : forwardsZeroSequence()) {
+        receiver.decodeQuarterFrameForTesting(m);
+    }
+
+    ASSERT_EQ(flags.size(), 8u)
+        << "forwards sequence must produce exactly 8 callback fires";
+    for (size_t i = 0; i < 7; ++i) {
+        EXPECT_FALSE(flags[i]) << "QF " << i << " should be extrapolated";
+    }
+    EXPECT_TRUE(flags[7]) << "QF 7 should carry isCompleteFrame=true";
+}
+
+TEST_F(CallbackFixture, InvalidSequenceProducesZeroTicks) {
+    // Feed a 3-QF sequence where direction never stabilizes: alternate
+    // 0x40, 0x20, 0x60 — neither forward nor backward monotone. Every QF's
+    // qfCount mismatches expected_qf_count → reset guard suppresses all fires.
+    MtcReceiver receiver(MtcReceiver::SkipPortOpenTag{});
+    receiver.resetDecoderStateForTesting();
+
+    std::atomic<int> hits{0};
+    MtcReceiver::setTickCallback([&](long, bool) { hits.fetch_add(1); });
+
+    for (auto type : {4u, 2u, 6u}) {
+        auto m = qf(static_cast<unsigned char>(type), 0);
+        receiver.decodeQuarterFrameForTesting(m);
+    }
+
+    EXPECT_EQ(hits.load(), 0)
+        << "invalid QF sequence must not fire any callback";
+}
+
+TEST_F(CallbackFixture, BackwardsSequenceFiresAfterDirectionStabilizes) {
+    // Backwards QF order: 7,6,5,4,3,2,1,0. direction isn't detected until the
+    // 3rd QF (qfCount > 1). The first two QFs fail the reset guard; the
+    // remaining 6 fire once each, and the final QF (type 0) is the complete
+    // frame — so 6 callbacks total, the last carries isCompleteFrame=true.
+    MtcReceiver receiver(MtcReceiver::SkipPortOpenTag{});
+    receiver.resetDecoderStateForTesting();
+
+    std::vector<bool> flags;
+    MtcReceiver::setTickCallback(
+        [&](long, bool isComplete) { flags.push_back(isComplete); });
+
+    for (int type = 7; type >= 0; --type) {
+        auto m = qf(static_cast<unsigned char>(type),
+                    type == 7 ? 2 : 0);  // rate bits on QF7
+        receiver.decodeQuarterFrameForTesting(m);
+    }
+
+    ASSERT_EQ(flags.size(), 6u)
+        << "backwards sequence must suppress the 2 warm-up QFs and fire 6 times";
+    for (size_t i = 0; i < 5; ++i) {
+        EXPECT_FALSE(flags[i]) << "QF index " << i << " should be extrapolated";
+    }
+    EXPECT_TRUE(flags.back()) << "final QF in backwards run must be complete";
+}
+
+// ─── getCurFrame snapshot consistency ────────────────────────────────────────
+
+TEST_F(CallbackFixture, GetCurFrameSnapshotIsConsistentUnderConcurrency) {
+    // Writers push full-frame SysEx messages with varying timecode values,
+    // readers repeatedly call getCurFrame. Without the curFrameMutex_ a
+    // reader could observe a torn frame (e.g., hours from one write, seconds
+    // from another) — this test asserts that every read is internally valid.
+    MtcReceiver receiver(MtcReceiver::SkipPortOpenTag{});
+
+    std::atomic<bool>    stop{false};
+    std::atomic<int>     tornReads{0};
+
+    auto makeFullFrame = [](int h, int m, int s, int f) -> Msg {
+        return {
+            0xF0, 0x7F, 0x7F, 0x01, 0x01,
+            static_cast<unsigned char>((h & 0x1F) | (1 << 5)),  // hours + 25 fps rate
+            static_cast<unsigned char>(m),
+            static_cast<unsigned char>(s),
+            static_cast<unsigned char>(f),
+            0xF7,
+        };
+    };
+
+    std::thread writer([&] {
+        int i = 0;
+        while (!stop.load()) {
+            Msg msg = makeFullFrame((i % 24), (i % 60), (i % 60), (i % 25));
+            receiver.decodeFullFrameForTesting(msg);
+            ++i;
+        }
+    });
+
+    std::thread reader([&] {
+        for (int i = 0; i < 10000 && !stop.load(); ++i) {
+            MtcFrame f = MtcReceiver::getCurFrame();
+            // A well-formed snapshot must satisfy these ranges. A torn read
+            // across the five field writes in decodeFullFrame would almost
+            // certainly violate one of them.
+            if (f.hours   > 23) tornReads.fetch_add(1);
+            if (f.minutes > 59) tornReads.fetch_add(1);
+            if (f.seconds > 59) tornReads.fetch_add(1);
+            if (f.frames  > 30) tornReads.fetch_add(1);
+        }
+        stop.store(true);
+    });
+
+    reader.join();
+    writer.join();
+
+    EXPECT_EQ(tornReads.load(), 0)
+        << "getCurFrame returned an inconsistent snapshot under concurrent writes";
+}


### PR DESCRIPTION
Replace the public `std::function<void(long)> onQuarterFrame` variable with a mutex-guarded `setTickCallback(TickCallback)` entry point, and collapse the previous double-fire on QF 8 (Site 1 + Site 2) into one invocation per valid quarter frame carrying a bool flag that distinguishes extrapolated ticks from the authoritative tick after full decode.

Why

 - The public std::function was non-atomic: a reader on the MIDI thread and a writer on any other thread produced undefined behavior. The only downstream caller today (gradient-motion-engine MtcTickSource) wrote to it exactly that way.
 - The double-fire gave consumers two callbacks for the same QF and required deduplication, plus it acquired the hot-path mutex twice with a window between sites where a racing setter could swap the target. One fire + isCompleteFrame removes that complexity.
 - Site 1 fired before the reset check, so invalid QF sequences emitted phantom ticks. Consumers are now only called when the sequence is valid.

What

 - TickCallback signature: void(long mtcHeadMs, bool isCompleteFrame). Fires once per valid QF. isCompleteFrame is true only on QF 8 after the full timecode frame is decoded.
 - setTickCallback({}) blocks until any in-flight handler returns, so the previous callback is guaranteed never to fire after an unregister returns (no-call-after-unregister).
 - wasLastUpdateFullFrame becomes std::atomic<bool> (fixes the race with the read/reset split in MtcReceiverMIDIDriver).
 - curFrame writes in decodeQuarterFrame/decodeFullFrame and reads in getCurFrame are serialized by curFrameMutex_ (fixes torn reads).
 - timecodeRunWeight, timecodeStartTimestamp, and timecodeTimestamp are protected by an instance-level mutable activeStateMutex_, also acquired by isTimecodeActive/estimatedCurrentHead and by the checker thread.
 - std::cout writes from the MIDI thread (blocking on flush) move behind MTCRECV_VERBOSE_DIAG and use fprintf; off by default.
 - MTCRECV_TESTING exposes test-only helpers (invokeTickForTesting, a SkipPortOpenTag constructor, decode forwarders, state reset) so the decoder can be driven from unit tests without MIDI hardware.
 - CMakeLists declares project(mtcreceiver VERSION 2.0.0) and adds MTCRECV_VERBOSE_DIAG, MTCRECV_TESTING, and MTCRECV_BUILD_TESTS options. Tests fetch googletest via FetchContent when needed.
 - New tests/ directory with 10 googletest cases covering the callback API, thread-safety guarantees, single-fire semantics on both forward and backward sequences, the reset guard, and getCurFrame snapshot consistency. Passes under -fsanitize=thread.

Breaking change

The static onQuarterFrame variable is removed. The only known consumer is gradient-motion-engine (MtcTickSource); its update lands in a coordinated PR once this is merged. Consumers of the other public statics (mtcHead, isTimecodeRunning, curFrameRate, wasLastUpdateFullFrame) are unaffected — wasLastUpdateFullFrame's atomic upgrade compiles through the existing read/write sites unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API change replacing the public callback variable with a mutex-guarded registration method and altering tick delivery semantics, which can impact downstream consumers and real-time MIDI callback behavior. Adds new locking around shared state that could affect timing if misused.
> 
> **Overview**
> **Refactors the quarter-frame callback API** by removing the public `onQuarterFrame` variable and introducing `MtcReceiver::setTickCallback(TickCallback)` with a new `(mtcHeadMs, isCompleteFrame)` signature and a *no-call-after-unregister* guarantee.
> 
> **Changes tick semantics** to fire at most once per *valid* quarter-frame (no more double-fire on the completing QF), suppressing callbacks for invalid QF sequences, and updates decoder paths to publish a consistent `curFrame` snapshot and make `wasLastUpdateFullFrame` atomic.
> 
> **Hardens thread-safety and testability** by adding mutex protection for `curFrame` and active-state timestamps/weights, gating verbose diagnostics behind `MTCRECV_VERBOSE_DIAG`, and adding CMake options plus a new `tests/` GoogleTest suite (with test-only hooks under `MTCRECV_TESTING`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd2366a72a9ed203927c2068511791e7f00ab839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->