### PR TITLE
Fix/mtcframe conversions and fullframe reset

### DIFF
--- a/mtcreceiver.cpp
+++ b/mtcreceiver.cpp
@@ -34,6 +34,7 @@
 #include "mtcreceiver.h"
 
 #include <cstdio>
+#include <stdexcept>
 
 ////////////////////////////////////////////
 // Initializing static class members
@@ -131,8 +132,7 @@ MtcReceiver::MtcReceiver( 	RtMidi::Api api,
     // Check for midi ports available
     if ( RtMidiIn::getPortCount() == 0 ) {
 		CuemsLogger::getLogger()->logError("No midi ports found.");
-
-        exit(CUEMS_EXIT_NO_MIDI_PORTS_FOUND);
+        throw std::runtime_error("MtcReceiver: no MIDI ports available");
     }
 
 	// Set and detach our threaded checker loop

--- a/mtcreceiver.cpp
+++ b/mtcreceiver.cpp
@@ -194,13 +194,11 @@ long int MtcFrame::toMilliseconds() const {
 
 //////////////////////////////////////////////////////////
 void MtcFrame::fromSeconds( long int s ) {
-	seconds = (int)s % 60;
-	minutes = (int)( (s - seconds) * (1 / 60) ) % 60;
-	hours = (int)(s * (1 / 3600) ) % 60;
-
-	// round fractional part of seconds for ms
-	long int ms = (int)(floor((s - floor(s)) * 1000.0) + 0.5);
-	frames = msToFrames(ms);
+	// `s` is whole seconds, so no fractional component to convert into frames.
+	seconds = (int)(s % 60);
+	minutes = (int)((s / 60) % 60);
+	hours   = (int)((s / 3600) % 24);
+	frames  = 0;
 }
 
 //////////////////////////////////////////////////////////

--- a/mtcreceiver.cpp
+++ b/mtcreceiver.cpp
@@ -203,7 +203,7 @@ void MtcFrame::fromSeconds( long int s ) {
 
 //////////////////////////////////////////////////////////
 long int MtcFrame::msToFrames( long int ms ) {
-	return ( ms / ( getFps() / 1000.0) );
+	return (long int)(ms * (getFps() / 1000.0));
 }
 
 //////////////////////////////////////////////////////////

--- a/mtcreceiver.cpp
+++ b/mtcreceiver.cpp
@@ -455,6 +455,16 @@ void MtcReceiver::decodeFullFrame(std::vector<unsigned char> &message) {
 			(timecodeStartTimestamp - clientStartTimestamp) * 1e-9);
 #endif
 	}
+
+	// A full frame is a seek / resync: any in-flight quarter-frame sequence
+	// is now stale. Clear the decoder state so the next QF stream starts
+	// fresh — otherwise direction / qfCount / firstQFlag / lastQFlag leak
+	// from before the seek and invalidate the sequence-validity check.
+	quarterFrame = MtcFrame();
+	direction = 0;
+	qfCount = 0;
+	lastQFlag = firstQFlag = false;
+	lastDataByte = 0x00;
 }
 
 //////////////////////////////////////////////////////////


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core MTC time conversion and decoder state, which can affect playback/seek synchronization and timing accuracy. Behavior changes should be validated across frame rates and during full-frame seek/resync events.
> 
> **Overview**
> Fixes several MIDI Time Code correctness issues in `mtcreceiver.cpp`.
> 
> `MtcReceiver` now throws an exception when no MIDI ports are available (instead of exiting the process). `MtcFrame` time conversions are corrected by making `fromSeconds()` treat its input as whole seconds (frames reset to 0) and fixing `msToFrames()` math.
> 
> On receiving a SysEx full-frame timecode, the quarter-frame decoder state is now cleared (`quarterFrame`, direction/count/flags) to avoid stale in-flight quarter-frame sequences corrupting subsequent decode/validity checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85d0598ae68936f6a560709f6b3078cc61e2e36e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->